### PR TITLE
Users can set needs unloading and unload appliances on the page

### DIFF
--- a/DoYouBehave/container/app/config/.default_config.yaml
+++ b/DoYouBehave/container/app/config/.default_config.yaml
@@ -53,6 +53,19 @@ things:
       planned_notifications:
         - mqtt_topic: home/things/robot-cleaner
           cron_expression: '* * * * * */30'
+  - name: Washer Kai
+    type: washing_machine
+    sources:
+      - mqtt_topic: measurements/home/indoor/washing_machine_kai/power
+        type: consumption
+      - mqtt_topic: home/things/washing_machine_kai/load
+        type: loading
+      - mqtt_topic: home/things/washing_machine_kai/unload
+        type: unloading
+    destinations:
+      planned_notifications:
+        - mqtt_topic: home/things/washing_machine_kai
+          cron_expression: '* * * * *'
   - name: Parents bedroom
     type: room
     temperature_thresholds:

--- a/DoYouBehave/features/environment.py
+++ b/DoYouBehave/features/environment.py
@@ -131,7 +131,10 @@ def appliances_setup(context, timeout=10, **kwargs):
                                 'measurements/home/indoor/dishwasher/power', 'home/things/dishwasher/load',
                                 'home/things/dishwasher/unload'),
         'Dryer': Appliance(mqtt_client, 'Dryer',
-                           'zigbee/home/indoor/dryer', 'home/things/dryer/load', 'home/things/dryer/unload')
+                           'zigbee/home/indoor/dryer', 'home/things/dryer/load', 'home/things/dryer/unload'),
+        'Washer Kai': Appliance(mqtt_client, 'Washer Kai',
+                                'measurements/home/indoor/washing_machine_kai/power/power',
+                                'home/things/washing_machine_kai/load', 'home/things/washing_machine_kai/unload')
     }
     context.rooms = {
         'Kitchen': Room(mqtt_client, 'Kitchen', 'zigbee/home/kitchen/sensor01'),

--- a/DoYouBehave/features/virtual_entities_overview.feature
+++ b/DoYouBehave/features/virtual_entities_overview.feature
@@ -33,6 +33,13 @@ Feature: Showing general information of virtual entities
     When the power consumption of the Dishwasher is updated to 5
     Then the user sees the new running state of the Dishwasher being loaded after a refresh
 
+  Scenario: The users can set that the washer needs unloading and unload it.
+    Given the user goes to the virtual entities page
+    When they click the needs unloading button of appliance Washer Kai
+    Then they see the new running state of the Washer Kai being loaded after a refresh
+    When they click the unload button of appliance Washer Kai
+    Then they see the new running state of the Washer Kai being idling after a refresh
+
   Scenario: Room climate updates are displayed
     Given the user goes to the virtual entities page
     When the room climate of the Kitchen is updated

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -46,7 +46,8 @@ def create_app(default_config_file_name: str, machine_service: MachineService, a
         "/appliance/<name>/configuration",
         view_func=Appliance.Configuration.as_view('appliance_configuration', machine_service, configuration_manager)
     )
-    app.register_blueprint(appliance_depot_api(appliance_depot, time_series_storage), url_prefix='/api/')
+    app.register_blueprint(appliance_depot_api(machine_service, appliance_depot, time_series_storage),
+                           url_prefix='/api/')
 
     app.add_url_rule(
         "/room/<name>",

--- a/flaskr/api/ApplianceDepot.py
+++ b/flaskr/api/ApplianceDepot.py
@@ -1,26 +1,38 @@
 from http import HTTPStatus
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, make_response
 
 from iot.core.configuration_manager import ConfigurationManager
 from iot.core.time_series_storage import TimeSeriesStorage
 from iot.infrastructure.machine.appliance_depot import ApplianceDepot
+from iot.infrastructure.machine.machine_service import MachineService
 
 
-def appliance_depot_api(appliance_depot: ApplianceDepot, time_series_storage: TimeSeriesStorage):
+def appliance_depot_api(appliance_service: MachineService, appliance_depot: ApplianceDepot,
+                        time_series_storage: TimeSeriesStorage):
     api = Blueprint('appliance-depot_api', __name__)
 
     @api.get('/appliances')
-    def all():
+    def inventory():
         return list(map(lambda a: a.to_dict(), appliance_depot.inventory()))
 
     @api.get('/appliances/<name>')
-    def single(name: str):
+    def details(name: str):
         return appliance_depot.retrieve(name).to_dict()
 
     @api.get('/appliances/<name>/power-consumptions')
-    def single_power_consumptions(name: str):
+    def power_consumptions(name: str):
         return list(
             map(lambda c: c.to_dict(), time_series_storage.get_power_consumptions_for_last_seconds(60 * 60 * 4, name)))
+
+    @api.post('/appliances/<name>/unload')
+    def unload(name: str):
+        appliance_service.unloaded(name)
+        return '', HTTPStatus.OK
+
+    @api.post('/appliances/<name>/load')
+    def load(name: str):
+        appliance_service.loaded(name, True)
+        return '', HTTPStatus.OK
 
     return api

--- a/flaskr/static/javascript/base.js
+++ b/flaskr/static/javascript/base.js
@@ -35,4 +35,18 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
         // Set the interval to update the time every second
         setInterval(updateElapsedTime, 60 * 1000);
     })
+
+    document.querySelectorAll('form').forEach(form => {
+        if (!form.dataset.apiUrl) return
+        form.onsubmit = event => {
+            if (event.preventDefault) event.preventDefault();
+            fetch(form.dataset.apiUrl, {method: "POST"}).then(() => {
+                window.location.reload()
+            })
+            return false;
+        }
+        form.querySelectorAll('[type="submit"]').forEach(submitElement => {
+            submitElement.removeAttribute('disabled')
+        })
+    })
 })()

--- a/flaskr/templates/snippets/appliance_sm.html
+++ b/flaskr/templates/snippets/appliance_sm.html
@@ -12,7 +12,7 @@
             {%- endwith %}
         </h4>
     </div>
-    <div class="row gap-1 g-0">
+    <div class="row g-1">
         <div class="col-4">
             <div class="w-100 position-relative" style="aspect-ratio: 1">
                 <div class="power-consumption diagram position-absolute top-0 start-0 w-100 h-100 z-2"
@@ -70,6 +70,23 @@
                 {%- endif %}
             </div>
         </div>
+        {%- if appliance.needs_unloading %}
+            <div class="col-4 d-flex flex-column align-items-center justify-content-center">
+                <form class="w-75" style="aspect-ratio: 1" method="get"
+                      action="#" data-api-url="{{ url_for('appliance-depot_api.unload', name=appliance.name ) }}">
+                    <button class="unload btn btn-outline-success p-0 w-100 h-100" disabled="disabled"
+                            type="submit" value="{{ _('Unload') }}">{{ _('Unload') }}</button>
+                </form>
+            </div>
+        {%- elif appliance.running_state!='running' %}
+            <div class="col-4 d-flex flex-column align-items-center justify-content-center">
+                <form class="w-75" style="aspect-ratio: 1" method="get"
+                      action="#" data-api-url="{{ url_for('appliance-depot_api.load', name=appliance.name ) }}">
+                    <button class="needs-unloading btn btn-outline-primary p-0 w-100 h-100" disabled="disabled"
+                            type="submit" value="{{ _('Needs unloading') }}">{{ _('Needs unloading') }}</button>
+                </form>
+            </div>
+        {%- endif %}
     </div>
     {%- if debug %}{{ appliance.to_dict() }}{% endif %}
 </div>


### PR DESCRIPTION
The following scenario is added to the virtual entities overview.

```gherkin
  Scenario: The users can set that the washer needs unloading and unload it.
    Given the user goes to the virtual entities page
    When they click the needs unloading button of appliance Washer Kai
    Then they see the new running state of the Washer Kai being loaded after a refresh
    When they click the unload button of appliance Washer Kai
    Then they see the new running state of the Washer Kai being idling after a refresh
```